### PR TITLE
 [Enhancement] Start timer on first move instead of game start

### DIFF
--- a/game15.c
+++ b/game15.c
@@ -226,7 +226,8 @@ static bool is_board_solved() {
 static void game_tick() {
     switch(game_state.scene) {
     case ScenePlay:
-        game_state.tick_count++;
+        if (game_state.move_count >= 1)
+            game_state.tick_count++;
         if (loaded_saving_ticks)
             loaded_saving_ticks--;
         if(moving_cell.move_direction == DirectionNone && !key_stack_is_empty()) {
@@ -367,7 +368,7 @@ static void render_callback(Canvas* const canvas) {
             canvas_draw_rbox(canvas, 20, 24, 88, 16, 4);
             canvas_set_color(canvas, ColorBlack);
             canvas_draw_rframe(canvas, 20, 24, 88, 16, 4);
-            canvas_draw_str_aligned(canvas, 64, 32, AlignCenter, AlignCenter, "Restore game ...");
+            canvas_draw_str_aligned(canvas, 64, 32, AlignCenter, AlignCenter, "Restoring game ...");
         }
     }
 


### PR DESCRIPTION
Changes:
1. Only run timer after player's first move;
2. Typo fix of 'Restore game ...' -> 'Restoring game ...';

Fixes #1.